### PR TITLE
idempotency fix

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
   raw: stat $HOME/.bootstrapped
   register: need_bootstrap
   ignore_errors: True
+  changed_when: False
 
 - name: Run bootstrap.sh
   script: bootstrap.sh


### PR DESCRIPTION
This sets when_changed false on the stat for the .bootstrapped file.
otherwise it registers changed everytime.

Signed-off-by: Duffie Cooley <dcooley@heptio.com>