### PR TITLE
Fix #6 Only able to install Python3.6 + PyPy 7.2.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,4 +4,4 @@ ansible_python_interpreter: "{{ ansible_python_dir }}/bin/python"
 
 python_version: "3.6"
 pypy_version: "7.2.0"
-pypy_download_template_url: "https://github.com/squeaky-pl/portable-pypy/releases/download/pypy$PYTHON_VERSION-$PYPY_VERSION/$pypyFile.tar.bz2"
+pypy_override_download_url: null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@ ansible_python_interpreter: "{{ ansible_python_dir }}/bin/python"
 
 python_version: "3.6"
 pypy_version: "7.2.0"
+pypy_download_template_url: "https://github.com/squeaky-pl/portable-pypy/releases/download/pypy$PYTHON_VERSION-$PYPY_VERSION/$pypyFile.tar.bz2"

--- a/files/install_python.sh
+++ b/files/install_python.sh
@@ -9,15 +9,15 @@ fi
 mkdir -p "$PYTHON_DIR"
 cd "$PYTHON_DIR"
 
-
 pypyFile="pypy$PYTHON_VERSION-$PYPY_VERSION-linux_x86_64-portable"
 tarFile="$PYTHON_DIR/$pypyFile.tar.bz2"
+pypy_url=${PYPY_OVERRIDE_DOWNLOAD_URL:-"https://github.com/squeaky-pl/portable-pypy/releases/download/pypy$PYTHON_VERSION-$PYPY_VERSION/$pypyFile.tar.bz2"}
 
 if [[ -e "$tarFile" ]]; then
   tar -xjf "$tarFile"
   rm -rf "$tarFile"
 else
-  wget -O - ${envsubst $PYPY_DOWNLOAD_TEMPLATE_URL} | tar -xjf -
+  wget -O - "$pypy_url" | tar -xjf -
 fi
 
 mv -n "$pypyFile" pypy

--- a/files/install_python.sh
+++ b/files/install_python.sh
@@ -9,15 +9,16 @@ fi
 mkdir -p "$PYTHON_DIR"
 cd "$PYTHON_DIR"
 
+
 pypyFile="pypy$PYTHON_VERSION-$PYPY_VERSION-linux_x86_64-portable"
 tarFile="$PYTHON_DIR/$pypyFile.tar.bz2"
-pypy_url=${PYPY_OVERRIDE_DOWNLOAD_URL:-"https://github.com/squeaky-pl/portable-pypy/releases/download/pypy$PYTHON_VERSION-$PYPY_VERSION/$pypyFile.tar.bz2"}
+pypyUrl=${PYPY_OVERRIDE_DOWNLOAD_URL:-"https://github.com/squeaky-pl/portable-pypy/releases/download/pypy$PYTHON_VERSION-$PYPY_VERSION/$pypyFile.tar.bz2"}
 
 if [[ -e "$tarFile" ]]; then
   tar -xjf "$tarFile"
   rm -rf "$tarFile"
 else
-  wget -O - "$pypy_url" | tar -xjf -
+  wget -O - "$pypyUrl" | tar -xjf -
 fi
 
 mv -n "$pypyFile" pypy

--- a/files/install_python.sh
+++ b/files/install_python.sh
@@ -17,7 +17,7 @@ if [[ -e "$tarFile" ]]; then
   tar -xjf "$tarFile"
   rm -rf "$tarFile"
 else
-  wget -O - "https://github.com/squeaky-pl/portable-pypy/releases/download/pypy$PYTHON_VERSION-$PYPY_VERSION/$pypyFile.tar.bz2" | tar -xjf -
+  wget -O - ${envsubst $PYPY_DOWNLOAD_TEMPLATE_URL} | tar -xjf -
 fi
 
 mv -n "$pypyFile" pypy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
     PYTHON_DIR: "{{ ansible_python_dir }}"
     PYTHON_VERSION: "{{ python_version }}"
     PYPY_VERSION: "{{ pypy_version }}"
-    PYPY_DOWNLOAD_TEMPLATE_URL: "{{ pypy_download_template_url }}"
+    PYPY_OVERRIDE_DOWNLOAD_URL: "{{ pypy_override_download_url|default('') }}"
   when: need_python is failed
 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,7 @@
     PYTHON_DIR: "{{ ansible_python_dir }}"
     PYTHON_VERSION: "{{ python_version }}"
     PYPY_VERSION: "{{ pypy_version }}"
+    PYPY_DOWNLOAD_TEMPLATE_URL: "{{ pypy_download_template_url }}"
   when: need_python is failed
 
 


### PR DESCRIPTION
The PR adds a configuration variable "pypy_override_download_url" enabling the user to override the download URL for pypy.