### PR TITLE
Add support for Fedora CoreOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,18 +12,19 @@ All user visible changes to this project will be documented in this file. This p
 
 #### BC Breaks
 
-- Drop support for [Container Linux CoreOS]
-- Switch from [portable PyPy] to official [PyPy] builds ([squeaky-pl/portable-pypy #97])
+- Drop support for [Container Linux CoreOS] ([#10]).
+- Switch from [portable PyPy] to official [PyPy] builds ([squeaky-pl/portable-pypy#97], [#10]).
 
 #### Added
 
-- Add support for [Fedora CoreOS]
+- Support for [Fedora CoreOS] ([#10]).
 
 #### Changed
 
-- Upgrade [PyPy] to [7.3.2][PyPy 7.3.2]
+- Upgrade [PyPy] to [7.3.2][PyPy 7.3.2] ([#10]).
 
-[squeaky-pl/portable-pypy #97]: https://github.com/squeaky-pl/portable-pypy/issues/97
+[squeaky-pl/portable-pypy#97]: https://github.com/squeaky-pl/portable-pypy/issues/97
+[#10]: https://github.com/instrumentisto/ansible-coreos-bootstrap/pull/7
 
 
 
@@ -104,9 +105,9 @@ All user visible changes to this project will be documented in this file. This p
 [2.0.0]: https://github.com/instrumentisto/ansible-coreos-bootstrap/tree/2.0.0
 [1.0.0]: https://github.com/instrumentisto/ansible-coreos-bootstrap/tree/1.0.0
 
-[Fedora CoreOS]: https://getfedora.org/en/coreos
-[Container Linux CoreOS]: https://coreos.com/os/docs/latest/
 [Ansible]: https://www.ansible.com
+[Container Linux CoreOS]: https://coreos.com/os/docs/latest
+[Fedora CoreOS]: https://getfedora.org/en/coreos
 [pip]: https://pypi.org/project/pip
 [portable PyPy]: https://github.com/squeaky-pl/portable-pypy
 [PyPy]: https://pypy.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [3.0.0] · 2020-11-??
+
+[Diff](https://github.com/instrumentisto/ansible-coreos-bootstrap/compare/2.1.0...3.0.0)
+
+#### BC Breaks
+
+- Drop support of [Container Linux CoreOS]
+- Switch from [portable PyPy] to official [PyPy] builds ([squeaky-pl/portable-pypy #97])
+
+#### Added
+
+- Add support of [Fedora CoreOS]
+
+#### Changed
+
+- Upgrade [PyPy] to [7.3.2][PyPy 7.3.2]
+
+[squeaky-pl/portable-pypy #97]: https://github.com/squeaky-pl/portable-pypy/issues/97
+
+
+
+
 ## [2.1.0] · 2020-10-19
 
 [Diff](https://github.com/instrumentisto/ansible-coreos-bootstrap/compare/2.0.0...2.1.0)
@@ -77,10 +99,13 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+[3.0.0]: https://github.com/instrumentisto/ansible-coreos-bootstrap/tree/3.0.0
 [2.1.0]: https://github.com/instrumentisto/ansible-coreos-bootstrap/tree/2.1.0
 [2.0.0]: https://github.com/instrumentisto/ansible-coreos-bootstrap/tree/2.0.0
 [1.0.0]: https://github.com/instrumentisto/ansible-coreos-bootstrap/tree/1.0.0
 
+[Fedora CoreOS]: https://getfedora.org/en/coreos
+[Container Linux CoreOS]: https://coreos.com/os/docs/latest/
 [Ansible]: https://www.ansible.com
 [pip]: https://pypi.org/project/pip
 [portable PyPy]: https://github.com/squeaky-pl/portable-pypy
@@ -88,4 +113,5 @@ All user visible changes to this project will be documented in this file. This p
 [Python 3.5]: https://www.python.org/downloads/release/python-350
 [Python 3.6]: https://www.python.org/downloads/release/python-360
 [PyPy 7.2.0]: http://doc.pypy.org/en/latest/release-v7.2.0.html
+[PyPy 7.3.2]: http://doc.pypy.org/en/latest/release-v7.3.2.html
 [Semantic Versioning 2.0.0]: https://semver.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
-## [3.0.0] · 2020-11-??
+## [3.0.0] · 2020-11-11
 
 [Diff](https://github.com/instrumentisto/ansible-coreos-bootstrap/compare/2.1.0...3.0.0)
 
@@ -24,7 +24,7 @@ All user visible changes to this project will be documented in this file. This p
 - Upgrade [PyPy] to [7.3.2][PyPy 7.3.2] ([#10]).
 
 [squeaky-pl/portable-pypy#97]: https://github.com/squeaky-pl/portable-pypy/issues/97
-[#10]: https://github.com/instrumentisto/ansible-coreos-bootstrap/pull/7
+[#10]: https://github.com/instrumentisto/ansible-coreos-bootstrap/pull/10
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ All user visible changes to this project will be documented in this file. This p
 
 #### BC Breaks
 
-- Drop support of [Container Linux CoreOS]
+- Drop support for [Container Linux CoreOS]
 - Switch from [portable PyPy] to official [PyPy] builds ([squeaky-pl/portable-pypy #97])
 
 #### Added
 
-- Add support of [Fedora CoreOS]
+- Add support for [Fedora CoreOS]
 
 #### Changed
 

--- a/README.md
+++ b/README.md
@@ -3,18 +3,16 @@ coreos-bootstrap
 
 [![GitHub release](https://img.shields.io/github/release/instrumentisto/ansible-coreos-bootstrap.svg)](https://github.com/instrumentisto/ansible-coreos-bootstrap/releases/latest) [![Build Status](https://travis-ci.org/instrumentisto/ansible-coreos-bootstrap.svg?branch=master)](https://travis-ci.org/instrumentisto/ansible-coreos-bootstrap) [![Python](https://img.shields.io/badge/Python-3.6-blue.svg)](https://www.pypy.org/) [![PyPy](https://img.shields.io/badge/PyPy-7.3.2-blue.svg)](https://www.pypy.org/)
 
-Control [Fedora CoreOS][CoreOS] with Ansible.
+Control [Fedora CoreOS] with Ansible.
 
-In order to effectively run [Ansible], the target machine needs to have a [Python] interpreter. [CoreOS] machines are minimal and do not ship with any version of [Python]. To get around this limitation we can install [PyPy], a lightweight [Python] interpreter. The `coreos-bootstrap` role will install [PyPy] for us and we will update our inventory file to use the installed python interpreter.
+In order to effectively run [Ansible], the target machine needs to have a [Python] interpreter. [Fedora CoreOS] machines are minimal and do not ship with any version of [Python]. To get around this limitation we can install [PyPy], a lightweight [Python] interpreter. The `coreos-bootstrap` role will install [PyPy] for us and we will update our inventory file to use the installed python interpreter.
 
 
 ## Installing Python on Fedora CoreOS
 
-Currently installing Python on [Fedora CoreOS][CoreOS] is not straightforward.
+At the moment, installing Python on [Fedora CoreOS] is not quite straightforward.
 
-You might need to disable `SELinux` or use workarounds from [How to make ansible work in Fedora CoreOS again #592]
-
-[How to make ansible work in Fedora CoreOS again #592]: https://github.com/coreos/fedora-coreos-tracker/issues/592
+You might need to disable [SELinux] or to use workarounds from [How to make ansible work in Fedora CoreOS again (coreos/fedora-coreos-tracker#592)](https://github.com/coreos/fedora-coreos-tracker/issues/592).
 
 ## Install
 
@@ -120,7 +118,8 @@ After bootstrap, you can use [Ansible] as usual to manage system services, insta
 
 
 [Ansible]: https://docs.ansible.com
-[CoreOS]: https://getfedora.org/en/coreos
+[Fedora CoreOS]: https://getfedora.org/en/coreos
 [Nginx]: https://hub.docker.com/_/nginx
 [PyPy]: http://pypy.org
 [Python]: https://www.python.org
+[SELinux]: https://www.redhat.com/en/topics/linux/what-is-selinux

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 coreos-bootstrap
 ================
 
-[![GitHub release](https://img.shields.io/github/release/instrumentisto/ansible-coreos-bootstrap.svg)](https://github.com/instrumentisto/ansible-coreos-bootstrap/releases/latest) [![Build Status](https://travis-ci.org/instrumentisto/ansible-coreos-bootstrap.svg?branch=master)](https://travis-ci.org/instrumentisto/ansible-coreos-bootstrap) [![Python](https://img.shields.io/badge/Python-3.6-blue.svg)](https://github.com/squeaky-pl/portable-pypy) [![PyPy](https://img.shields.io/badge/Portable%20PyPy-7.3.2-blue.svg)](https://github.com/squeaky-pl/portable-pypy)
+[![GitHub release](https://img.shields.io/github/release/instrumentisto/ansible-coreos-bootstrap.svg)](https://github.com/instrumentisto/ansible-coreos-bootstrap/releases/latest) [![Build Status](https://travis-ci.org/instrumentisto/ansible-coreos-bootstrap.svg?branch=master)](https://travis-ci.org/instrumentisto/ansible-coreos-bootstrap) [![Python](https://img.shields.io/badge/Python-3.6-blue.svg)](https://www.pypy.org/) [![PyPy](https://img.shields.io/badge/PyPy-7.3.2-blue.svg)](https://www.pypy.org/)
 
 Experimental branch for [Fedora CoreOS][CoreOS].
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 coreos-bootstrap
 ================
 
-[![GitHub release](https://img.shields.io/github/release/instrumentisto/ansible-coreos-bootstrap.svg)](https://github.com/instrumentisto/ansible-coreos-bootstrap/releases/latest) [![Build Status](https://travis-ci.org/instrumentisto/ansible-coreos-bootstrap.svg?branch=master)](https://travis-ci.org/instrumentisto/ansible-coreos-bootstrap) [![Python](https://img.shields.io/badge/Python-3.5-blue.svg)](https://github.com/squeaky-pl/portable-pypy) [![PyPy](https://img.shields.io/badge/Portable%20PyPy-6.0.0-blue.svg)](https://github.com/squeaky-pl/portable-pypy)
+[![GitHub release](https://img.shields.io/github/release/instrumentisto/ansible-coreos-bootstrap.svg)](https://github.com/instrumentisto/ansible-coreos-bootstrap/releases/latest) [![Build Status](https://travis-ci.org/instrumentisto/ansible-coreos-bootstrap.svg?branch=master)](https://travis-ci.org/instrumentisto/ansible-coreos-bootstrap) [![Python](https://img.shields.io/badge/Python-3.6-blue.svg)](https://github.com/squeaky-pl/portable-pypy) [![PyPy](https://img.shields.io/badge/Portable%20PyPy-7.3.2-blue.svg)](https://github.com/squeaky-pl/portable-pypy)
+
+Experimental branch for [Fedora CoreOS][CoreOS].
 
 In order to effectively run [Ansible], the target machine needs to have a [Python] interpreter. [CoreOS] machines are minimal and do not ship with any version of [Python]. To get around this limitation we can install [PyPy], a lightweight [Python] interpreter. The `coreos-bootstrap` role will install [PyPy] for us and we will update our inventory file to use the installed python interpreter.
 
@@ -112,7 +114,7 @@ After bootstrap, you can use [Ansible] as usual to manage system services, insta
 
 
 [Ansible]: https://docs.ansible.com
-[CoreOS]: https://coreos.com/why
+[CoreOS]: https://getfedora.org/en/coreos
 [Nginx]: https://hub.docker.com/_/nginx
 [PyPy]: http://pypy.org
 [Python]: https://www.python.org

--- a/README.md
+++ b/README.md
@@ -3,12 +3,18 @@ coreos-bootstrap
 
 [![GitHub release](https://img.shields.io/github/release/instrumentisto/ansible-coreos-bootstrap.svg)](https://github.com/instrumentisto/ansible-coreos-bootstrap/releases/latest) [![Build Status](https://travis-ci.org/instrumentisto/ansible-coreos-bootstrap.svg?branch=master)](https://travis-ci.org/instrumentisto/ansible-coreos-bootstrap) [![Python](https://img.shields.io/badge/Python-3.6-blue.svg)](https://www.pypy.org/) [![PyPy](https://img.shields.io/badge/PyPy-7.3.2-blue.svg)](https://www.pypy.org/)
 
-Experimental branch for [Fedora CoreOS][CoreOS].
+Control [Fedora CoreOS][CoreOS] with Ansible.
 
 In order to effectively run [Ansible], the target machine needs to have a [Python] interpreter. [CoreOS] machines are minimal and do not ship with any version of [Python]. To get around this limitation we can install [PyPy], a lightweight [Python] interpreter. The `coreos-bootstrap` role will install [PyPy] for us and we will update our inventory file to use the installed python interpreter.
 
 
+## Installing Python on Fedora CoreOS
 
+Currently installing Python on [Fedora CoreOS][CoreOS] is not straightforward.
+
+You might need to disable `SELinux` or use workarounds from [How to make ansible work in Fedora CoreOS again #592]
+
+[How to make ansible work in Fedora CoreOS again #592]: https://github.com/coreos/fedora-coreos-tracker/issues/592
 
 ## Install
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,5 +3,5 @@ ansible_python_dir: /opt/python
 ansible_python_interpreter: "{{ ansible_python_dir }}/bin/python"
 
 python_version: "3.6"
-pypy_version: "7.2.0"
+pypy_version: "7.3.2"
 pypy_override_download_url: null

--- a/files/install_python.sh
+++ b/files/install_python.sh
@@ -6,23 +6,11 @@ set -e
 if [[ -d "$PYTHON_DIR" ]]; then
   rm -rf "$PYTHON_DIR"
 fi
-mkdir -p "$PYTHON_DIR"
+mkdir -p "$PYTHON_DIR/pypy/"
 cd "$PYTHON_DIR"
 
-
-pypyFile="pypy$PYTHON_VERSION-$PYPY_VERSION-linux_x86_64-portable"
-tarFile="$PYTHON_DIR/$pypyFile.tar.bz2"
-pypyUrl=${PYPY_OVERRIDE_DOWNLOAD_URL:-"https://github.com/squeaky-pl/portable-pypy/releases/download/pypy$PYTHON_VERSION-$PYPY_VERSION/$pypyFile.tar.bz2"}
-
-if [[ -e "$tarFile" ]]; then
-  tar -xjf "$tarFile"
-  rm -rf "$tarFile"
-else
-  wget -O - "$pypyUrl" | tar -xjf -
-fi
-
-mv -n "$pypyFile" pypy
-
+pypyUrl=${PYPY_OVERRIDE_DOWNLOAD_URL:-"https://downloads.python.org/pypy/pypy$PYTHON_VERSION-v$PYPY_VERSION-linux64.tar.bz2"}
+curl -L "$pypyUrl" | tar -C pypy --strip-components 1 -xjf -
 
 mkdir -p "$PYTHON_DIR/bin/"
 


### PR DESCRIPTION
FCM
```
Support Fedora CoreOS (#10)

- drop support for Container Linux CoreOS
- describe "Installing Python on Fedora CoreOS" section in README
- update CHANGELOG

Additionally:
- switch to official PyPy builds
- upgrade PyPy to 7.3.2 version
```

Additionally, switched from [portable PyPy] to official [PyPy] builds ([squeaky-pl/portable-pypy #97])

> Note: As of PyPy 7.3.0 the general direction and some patches from Portable PyPy were adapted/incorporated into upstream. For 7.3.0 and newer just go to official PyPy downloads page http://pypy.org/download.html and grab Linux x86-64 binary (64bit, built on CentOS6).

Before merge:

- [x] Set release date

[portable PyPy]: https://github.com/squeaky-pl/portable-pypy
[PyPy]: https://pypy.org
[squeaky-pl/portable-pypy #97]: https://github.com/squeaky-pl/portable-pypy/issues/97