### PR TITLE
Fix: python 3.6 script is somewhere else

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,7 @@ ansible_python_interpreter: "{{ ansible_python_dir }}/bin/python"
 python_version: "3.6"
 pypy_version: "7.3.2"
 pypy_override_download_url: null
+
+# latest version (currently: 3.7): https://bootstrap.pypa.io/get-pip.py
+# previous versions can be downloaded with a URL in the path
+pypy_pip_bootstrap: "https://bootstrap.pypa.io/pip/{{ python_version }}/get-pip.py"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,10 +4,12 @@ dependencies: []
 galaxy_info:
   role_name: coreos-bootstrap
   author: instrumentisto
-  description: Bootstrap CoreOS hosts to run Ansible
+  description: Bootstrap Flatcar Linux hosts to run Ansible
   license: MIT
   min_ansible_version: 2.5
   galaxy_tags:
     - system
     - coreos
     - python
+    - flatcar
+    - flatcar-linux

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
   changed_when: False
 
 - name: Install pip
-  shell: "curl https://bootstrap.pypa.io/get-pip.py | {{ ansible_python_interpreter }}"
+  shell: "curl {{ pypy_pip_bootstrap }} | {{ ansible_python_interpreter }}"
   args:
     warn: false
   when: need_pip is failed


### PR DESCRIPTION
This failed this morning. The location of the `3.6` setup file moved. So I made it a var, that can be adjusted.