### PR TITLE
Fix incompatibility with Ansible 7

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,8 +24,6 @@
 
 - name: Install pip
   shell: "curl {{ pypy_pip_bootstrap_url }} | {{ ansible_python_interpreter }}"
-  args:
-    warn: false
   when: need_pip.rc != 0
 
 - name: Install pip launcher


### PR DESCRIPTION
Ansible 7 [removes][1] deprecated `warn` parameter in the `shell` module which breaks execution of this role.

There is not much information about this parameter in the [docs][2].    
It looks like it was used to suppress warning that advised to use native Ansible module instead of the shell command ([source][3]):  

```
 [WARNING]: Consider using the file module with state=touch rather than running 'touch'.  If you need to use command because file is insufficient you can add 'warn: false' to this command task or set 'command_warnings=False' in ansible.cfg to get rid of this message.
```

In our case it was preventing warning to use [ansible.builtin.uri] module instead of `curl`.

[ansible.builtin.uri]: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/uri_module.html

FCM
```
Fix incompatibility with Ansible 7 (#13)

- remove deprecated and no longer supported `warn` parameter of the `shell` module
```

After MR is merged I'm going to prepare release `3.2.0` (which will also include #12) and also create `coreos` branch and prepare release `2.2.0` for Container Linux CoreOS with this fix.

[1]: https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_7.html#id37
[2]: https://docs.ansible.com/ansible/2.9/modules/shell_module.html#parameters
[3]: https://github.com/ansible/ansible/pull/77411/files#diff-68255781385e3dde7f25291144c15a32ffbf25d447f33568de7cba3b38f9b664