### PR TITLE
Add support for Ansible 10 and greater

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 coreos-bootstrap
 ================
 
-[![GitHub release](https://img.shields.io/github/release/instrumentisto/ansible-coreos-bootstrap.svg)](https://github.com/instrumentisto/ansible-coreos-bootstrap/releases/latest) [![Build Status](https://travis-ci.org/instrumentisto/ansible-coreos-bootstrap.svg?branch=master)](https://travis-ci.org/instrumentisto/ansible-coreos-bootstrap) [![Python](https://img.shields.io/badge/Python-3.6-blue.svg)](https://www.pypy.org/) [![PyPy](https://img.shields.io/badge/PyPy-7.3.2-blue.svg)](https://www.pypy.org/)
+[![GitHub release](https://img.shields.io/github/release/instrumentisto/ansible-coreos-bootstrap.svg)](https://github.com/instrumentisto/ansible-coreos-bootstrap/releases/latest) [![Build Status](https://travis-ci.org/instrumentisto/ansible-coreos-bootstrap.svg?branch=master)](https://travis-ci.org/instrumentisto/ansible-coreos-bootstrap) [![Python](https://img.shields.io/badge/Python-3.11-blue.svg)](https://www.pypy.org/) [![PyPy](https://img.shields.io/badge/PyPy-7.3.19-blue.svg)](https://www.pypy.org/)
 
 Control [Fedora CoreOS] with Ansible.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,11 +2,9 @@ ansible_ssh_user: core
 ansible_python_dir: /opt/python
 ansible_python_interpreter: "{{ ansible_python_dir }}/bin/python"
 
-python_version: "3.6"
+python_version: "3.11"
 
-pypy_version: "7.3.2"
+pypy_version: "7.3.19"
 pypy_override_download_url: null
 
-# Latest version: https://bootstrap.pypa.io/get-pip.py
-# Previous versions better be downloaded with a version in the URL path.
-pypy_pip_bootstrap_url: "https://bootstrap.pypa.io/pip/{{ python_version }}/get-pip.py"
+pypy_pip_bootstrap_url: "https://bootstrap.pypa.io/get-pip.py"


### PR DESCRIPTION
Ansible 10+ requires Python 3.7 or greater:

- https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html

PyPy currently support Python 3.11. https://pypy.org

Newer PyPy versions work only with the new `pypy_pip_bootstrap_url` `https://bootstrap.pypa.io/get-pip.py`.

Tested on Ansible 11.

FCM
```
Add support for Ansible 10 and greater

- upgrade to Python 3.11 and PyPy to 7.3.19
- use new `pypy_pip_bootstrap_url` for Python 3.8 and greater
```